### PR TITLE
fixing issue with generate block

### DIFF
--- a/RTL/final_design/AES_encrypt.v
+++ b/RTL/final_design/AES_encrypt.v
@@ -1,36 +1,37 @@
 module AES_encrypt #(
-    parameter key_length = 128, Nk = 4 , Nr = Nk+6
+    parameter key_length = 128, Nk = 4, Nr = Nk+6
 ) (
     input [0:127] plain_txt,
     input [0:key_length-1] key, 
     output [0:127] cipher_txt
 );
 
-//localparam Nb = 4;
-wire [0 : (128 * (Nr + 1)) - 1] expanded_key ;
-wire [0:127] new_state, new_state_loop;
-wire [0:127] sub_out,sub_out_final;
-wire [0:127] shift_out, shift_out_final;
-wire [0:127] mix_out;
+wire [0 : (128 * (Nr + 1)) - 1] expanded_key;
+wire [0:127] round_states [0:Nr];
+wire [0:127] sub_out_final, shift_out_final;
 
 Key_Expansion #(.Nk(Nk)) key_exp_inst (
     .key(key),
     .expanded_key(expanded_key)
 ); 
-AddRoundKey add_inst (
+
+AddRoundKey add_inst_init (
     .state(plain_txt),
     .round_key(expanded_key[0:127]),
-    .new_state(new_state)
+    .new_state(round_states[0])
 );
 
 genvar i;
 generate
-    for (i = 1; i<Nr; i=i+1) begin
-        subByte sub_inst(
-            .in(new_state),
-            .out(sub_out));
+    for (i = 1; i < Nr; i = i + 1) begin
+        wire [0:127] sub_out, shift_out, mix_out;
 
-        ShiftRows #(.enc_dec(0)) shift_inst(
+        subByte sub_inst (
+            .in(round_states[i-1]),
+            .out(sub_out)
+        );
+
+        ShiftRows #(.enc_dec(0)) shift_inst (
             .state(sub_out),
             .new_state(shift_out)
         );
@@ -39,27 +40,29 @@ generate
             .in(shift_out),
             .out(mix_out)        
         );
-        AddRoundKey add_inst_2 (
+
+        AddRoundKey add_inst_round (
             .state(mix_out),
             .round_key(expanded_key[i*128 +: 128]),
-            .new_state(new_state_loop)        
+            .new_state(round_states[i])
         );
     end
-
-    subByte sub_inst_2 (
-        .in(new_state_loop),
-        .out(sub_out_final)
-    );
-    ShiftRows #(.enc_dec(0)) shift_inst_2 (
-        .state(sub_out_final),
-        .new_state(shift_out_final)
-    );
-    AddRoundKey add_inst_3 (
-        .state(shift_out_final),
-        .round_key(expanded_key[(Nr)*128+:128]),
-        .new_state(cipher_txt)        
-    );
 endgenerate
 
+subByte sub_inst_final (
+    .in(round_states[Nr-1]),
+    .out(sub_out_final)
+);
+
+ShiftRows #(.enc_dec(0)) shift_inst_final (
+    .state(sub_out_final),
+    .new_state(shift_out_final)
+);
+
+AddRoundKey add_inst_final (
+    .state(shift_out_final),
+    .round_key(expanded_key[Nr*128+:128]),
+    .new_state(cipher_txt)        
+);
 
 endmodule


### PR DESCRIPTION
1- round_states array ensures that each round correctly updates and passes values forward.
2- make signals inside generate block Each round now correctly depends on the previous round’s state so preventing undefined (x) values.